### PR TITLE
Add _modelOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ local User = Model({
 
 ##### Table Configuration #####
 
-
 | Option  | Description              | Default Value |
 |---------|--------------------------|---------------|
 | name    | The name of the table    | -             |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Available connection types are:
 
 After initializing the ORM you can start creating the models for your tables. <br />
 A table contains one or more table columns and must contain exactly one primary key column. <br />
-If no primary key column is defined, a "id" column will be automatically added to the table.
+If no primary key column is defined, a "id" column will be automatically added to the table.  <br />
+The first parameter of `Model()` are the Table Configuration settings. The second parameter are the Model Options settings.  <br />
+The second parameter is optional.
 
 ```lua
 local Model = API.Model
@@ -90,13 +92,25 @@ local User = Model({
     { name = "job", fieldType = fieldTypes.charField, maxLength = 50, mustBeSet = false },
     { name = "time_create", fieldType = fieldTypes.dateTimeField, mustBeSet = false }
   }
-})
+},
+    { createTable =  true }
+)
 ```
+
+
+##### Table Configuration #####
+
 
 | Option  | Description              | Default Value |
 |---------|--------------------------|---------------|
 | name    | The name of the table    | -             |
 | columns | The columns of the table | -             |
+
+##### Model Options #####
+
+| Option      | Description                                                  | Default Value |
+|-------------|--------------------------------------------------------------|---------------|
+| createTable | Creates the table in the database when calling `Model()`     | `true`        |
 
 
 #### Table columns ####

--- a/src/LuaORM/Model.lua
+++ b/src/LuaORM/Model.lua
@@ -36,13 +36,18 @@ Model.targetTable = nil
 --
 -- @tparam mixed[] _tableConfiguration The table configuration of this Model's table
 --
+-- @tparam table _modelOptions The options for this model.
+--
 -- @treturn Model The Model instance
 --
-function Model:__construct(_tableConfiguration)
+function Model:__construct(_tableConfiguration, _modelOptions)
 
   local instance = setmetatable({}, {__index = Model})
   instance.targetTable = Table(_tableConfiguration)
-  instance:createTable()
+
+  if _modelOptions.createTable == nil or _modelOptions.createTable ~= false then
+    instance:createTable()
+  end
 
   return instance
 

--- a/src/LuaORM/Model.lua
+++ b/src/LuaORM/Model.lua
@@ -36,7 +36,7 @@ Model.targetTable = nil
 --
 -- @tparam mixed[] _tableConfiguration The table configuration of this Model's table
 --
--- @tparam table _modelOptions The options for this model.
+-- @tparam table _modelOptions The options for this model. (optional)
 --
 -- @treturn Model The Model instance
 --
@@ -44,6 +44,10 @@ function Model:__construct(_tableConfiguration, _modelOptions)
 
   local instance = setmetatable({}, {__index = Model})
   instance.targetTable = Table(_tableConfiguration)
+
+  if _modelOptions == nil then
+    _modelOptions = {}
+  end
 
   if _modelOptions.createTable == nil or _modelOptions.createTable ~= false then
     instance:createTable()

--- a/src/LuaORM/Model.lua
+++ b/src/LuaORM/Model.lua
@@ -51,6 +51,8 @@ function Model:__construct(_tableConfiguration, _modelOptions)
 
   if _modelOptions.createTable == nil or _modelOptions.createTable ~= false then
     instance:createTable()
+  else
+    instance.targetTable:validate()
   end
 
   return instance


### PR DESCRIPTION
Adding `_modelOptions` with a parameter of `createTable` to allow the flexibility of not creating tables every time a model is created.